### PR TITLE
Added a simple Oneliner for Raspberry-Installation

### DIFF
--- a/docs/Platforms.md
+++ b/docs/Platforms.md
@@ -24,6 +24,17 @@ https://github.com/esp8266/Arduino#installing-with-boards-manager13
 
 ## Linux (Raspberry Pi)
 
+
+###One-Line-Install
+
+Open a commandline and paste:
+```bash
+curl https://gist.githubusercontent.com/csicar/c2d9e492159ddce56f34/raw/5acdf89cb7f998790c159c1bc86c932e2838257a/blynk-install.sh | sh
+```
+Blynk will be installed with all dependencies and added to the autorun on linux.
+
+###Manual
+
 0. Connect your Raspberry Pi to the internet and open it's console. ^_^
 
 1. Install WiringPi:


### PR DESCRIPTION
Making the installation of Blynk easier.
Code can be found [here](https://gist.github.com/csicar/c2d9e492159ddce56f34)
(If preferred the script can be added to the official bynk repo)