### PR TITLE
Made some examples compatible with codebender

### DIFF
--- a/examples/BoardsAndShields/Arduino_M0_Serial/Arduino_M0_Serial.ino
+++ b/examples/BoardsAndShields/Arduino_M0_Serial/Arduino_M0_Serial.ino
@@ -55,6 +55,7 @@
 
 #define BLYNK_PRINT SerialUSB
 #include <BlynkSimpleSerial.h>
+#include <BlynkSimpleEthernet.h>
 
 // You should get Auth Token in the Blynk App.
 // Go to the Project Settings (nut icon).

--- a/examples/BoardsAndShields/Arduino_Serial_USB/Arduino_Serial_USB.ino
+++ b/examples/BoardsAndShields/Arduino_Serial_USB/Arduino_Serial_USB.ino
@@ -58,6 +58,7 @@
 SoftwareSerial SwSerial(2, 3); // RX, TX
 #define BLYNK_PRINT SwSerial
 #include <BlynkSimpleSerial.h>
+#include <BlynkSimpleEthernet.h>
 
 // You should get Auth Token in the Blynk App.
 // Go to the Project Settings (nut icon).

--- a/examples/BoardsAndShields/Arduino_SoftwareSerial/Arduino_SoftwareSerial.ino
+++ b/examples/BoardsAndShields/Arduino_SoftwareSerial/Arduino_SoftwareSerial.ino
@@ -21,6 +21,7 @@
 
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <SoftwareSerial.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkApiArduino.h>
 #include <Adapters/BlynkSerial.h>
 

--- a/examples/BoardsAndShields/Arduino_WiFi/Arduino_WiFi.ino
+++ b/examples/BoardsAndShields/Arduino_WiFi/Arduino_WiFi.ino
@@ -26,6 +26,7 @@
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <SPI.h>
 #include <WiFi.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleWifi.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/Arduino_Yun/Arduino_Yun.ino
+++ b/examples/BoardsAndShields/Arduino_Yun/Arduino_Yun.ino
@@ -21,6 +21,7 @@
 
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <Bridge.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleYun.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/CC3000/CC3000.ino
+++ b/examples/BoardsAndShields/CC3000/CC3000.ino
@@ -37,6 +37,7 @@
 
 #include <SPI.h>
 #include <Adafruit_CC3000.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleCC3000.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/ENC28J60/ENC28J60.ino
+++ b/examples/BoardsAndShields/ENC28J60/ENC28J60.ino
@@ -35,6 +35,7 @@
 
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <UIPEthernet.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleUIPEthernet.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/ESP8266_DirectConnect/ESP8266_DirectConnect.ino
+++ b/examples/BoardsAndShields/ESP8266_DirectConnect/ESP8266_DirectConnect.ino
@@ -30,6 +30,7 @@
 //#define BLYNK_DEBUG
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <ESP8266WiFi.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleUserDefined.h>
 
 // Uncomment this to set WiFi to Access Point mode

--- a/examples/BoardsAndShields/ESP8266_Shield_HardSer/ESP8266_Shield_HardSer.ino
+++ b/examples/BoardsAndShields/ESP8266_Shield_HardSer/ESP8266_Shield_HardSer.ino
@@ -29,6 +29,7 @@
 //#define BLYNK_DEBUG
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <ESP8266_HardSer.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleShieldEsp8266_HardSer.h>
 
 // Set ESP8266 Serial object

--- a/examples/BoardsAndShields/ESP8266_Shield_SoftSer/ESP8266_Shield_SoftSer.ino
+++ b/examples/BoardsAndShields/ESP8266_Shield_SoftSer/ESP8266_Shield_SoftSer.ino
@@ -31,6 +31,7 @@
 //#define BLYNK_DEBUG
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <ESP8266_SoftSer.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleShieldEsp8266_SoftSer.h>
 
 // Set ESP8266 Serial object

--- a/examples/BoardsAndShields/ESP8266_Standalone/ESP8266_Standalone.ino
+++ b/examples/BoardsAndShields/ESP8266_Standalone/ESP8266_Standalone.ino
@@ -27,6 +27,7 @@
 
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <ESP8266WiFi.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleEsp8266.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/Energia_WiFi/Energia_WiFi.ino
+++ b/examples/BoardsAndShields/Energia_WiFi/Energia_WiFi.ino
@@ -23,6 +23,7 @@
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <SPI.h>
 #include <WiFi.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleEnergiaWiFi.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/Intel_Edison_WiFi/Intel_Edison_WiFi.ino
+++ b/examples/BoardsAndShields/Intel_Edison_WiFi/Intel_Edison_WiFi.ino
@@ -22,6 +22,7 @@
 
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <WiFi.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleIntelEdisonWiFi.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/LinkItONE/LinkItONE.ino
+++ b/examples/BoardsAndShields/LinkItONE/LinkItONE.ino
@@ -22,6 +22,7 @@
  **************************************************************/
 #include <LWiFi.h>
 #include <LWiFiClient.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleLinkItONE.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/RN_XV_WiFly/RN_XV_WiFly.ino
+++ b/examples/BoardsAndShields/RN_XV_WiFly/RN_XV_WiFly.ino
@@ -30,6 +30,7 @@
 
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <WiFlyHQ.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleWiFly.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/RedBearLab_CC3200/RedBearLab_CC3200.ino
+++ b/examples/BoardsAndShields/RedBearLab_CC3200/RedBearLab_CC3200.ino
@@ -23,6 +23,7 @@
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <SPI.h>
 #include <WiFi.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleRBL_CC3200.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/RedBearLab_WiFi_Mini/RedBearLab_WiFi_Mini.ino
+++ b/examples/BoardsAndShields/RedBearLab_WiFi_Mini/RedBearLab_WiFi_Mini.ino
@@ -23,6 +23,7 @@
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <SPI.h>
 #include <WiFi.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleRBL_WiFi_Mini.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/Seeed_EthernetV2_0/Seeed_EthernetV2_0.ino
+++ b/examples/BoardsAndShields/Seeed_EthernetV2_0/Seeed_EthernetV2_0.ino
@@ -30,6 +30,7 @@
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <SPI.h>
 #include <EthernetV2_0.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleEthernetV2_0.h>
 
 #define W5200_CS  10

--- a/examples/BoardsAndShields/TI_CC3200_LaunchXL/TI_CC3200_LaunchXL.ino
+++ b/examples/BoardsAndShields/TI_CC3200_LaunchXL/TI_CC3200_LaunchXL.ino
@@ -23,6 +23,7 @@
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <SPI.h>
 #include <WiFi.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleTI_CC3200_LaunchXL.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/TI_Stellaris_LaunchPad/TI_Stellaris_LaunchPad.ino
+++ b/examples/BoardsAndShields/TI_Stellaris_LaunchPad/TI_Stellaris_LaunchPad.ino
@@ -54,6 +54,7 @@
  **************************************************************/
 
 #define BLYNK_PRINT Serial1
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleSerial.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/TI_TivaC_Connected/TI_TivaC_Connected.ino
+++ b/examples/BoardsAndShields/TI_TivaC_Connected/TI_TivaC_Connected.ino
@@ -22,6 +22,7 @@
 
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <Ethernet.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleTI_TivaC_Connected.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/TinyDuino_WiFi/TinyDuino_WiFi.ino
+++ b/examples/BoardsAndShields/TinyDuino_WiFi/TinyDuino_WiFi.ino
@@ -26,6 +26,7 @@
 #define BLYNK_PRINT Serial    // Comment this out to disable prints and save space
 #include <SPI.h>
 #include <Adafruit_CC3000.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleTinyDuino.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/User_Defined_Connection/User_Defined_Connection.ino
+++ b/examples/BoardsAndShields/User_Defined_Connection/User_Defined_Connection.ino
@@ -29,6 +29,7 @@
  *
  **************************************************************/
 
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleUserDefined.h>
 
 // You should get Auth Token in the Blynk App.

--- a/examples/BoardsAndShields/WildFire/WildFire.ino
+++ b/examples/BoardsAndShields/WildFire/WildFire.ino
@@ -32,6 +32,7 @@
 #include <SPI.h>
 #include <WildFire.h>
 #include <WildFire_CC3000.h>
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleWildFire.h>
 
 WildFire wildfire;

--- a/examples/More/LightBlueBeanRGB/LightBlueBeanRGB.ino
+++ b/examples/More/LightBlueBeanRGB/LightBlueBeanRGB.ino
@@ -1,6 +1,7 @@
 
 #define BLYNK_NO_YIELD
 
+#include <BlynkSimpleEthernet.h>
 #include <BlynkSimpleSerial.h>
 
 // You should get Auth Token in the Blynk App.


### PR DESCRIPTION
Hi guys! This is Fotis from [codebender](https://codebender.cc).
I modified some of the Blynk Library examples making them compatible with codebender. As you might already know, codebender only identifies that a project uses Blynk Library if the `#include BlynkSimpleEthernet.h` statement is present in the `.ino` file of the project. The modified examples should include BlynkSimpleEthernet.h file too in order to compile on codebender. This shouldn't affect their former behavior at all.

Thanks a lot!