### PR TITLE
linux: reduce warnings

### DIFF
--- a/linux/BlynkSocket.h
+++ b/linux/BlynkSocket.h
@@ -28,7 +28,7 @@ class BlynkTransportSocket
 {
 public:
     BlynkTransportSocket()
-        : sockfd(-1)
+        : sockfd(-1), domain(NULL), port(NULL)
     {}
 
     void begin(const char* d, const char* p) {


### PR DESCRIPTION
Eliminates some effc++ warnings.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>