### PR TITLE
Call BlynkOnConnected in direct connect mode

### DIFF
--- a/Blynk/BlynkProtocol.h
+++ b/Blynk/BlynkProtocol.h
@@ -278,6 +278,7 @@ bool BlynkProtocol<Transp>::processInput(void)
             state = CONNECTED;
             sendCmd(BLYNK_CMD_RESPONSE, hdr.msg_id, NULL, BLYNK_SUCCESS);
             this->sendInfo();
+            BlynkOnConnected();
         } else {
             BLYNK_LOG1(BLYNK_F("Invalid token"));
             sendCmd(BLYNK_CMD_RESPONSE, hdr.msg_id, NULL, BLYNK_INVALID_TOKEN);


### PR DESCRIPTION
Need to do this in order to sync values on connect. There seem to be broader issues with value writing though, I'll raise an issue separately. BlynkOnDisconnect() would need to be added too, but this is work-in-progress.
