### PR TITLE
Add new device : WizFi310

### DIFF
--- a/src/BlynkSimpleWizFi310.h
+++ b/src/BlynkSimpleWizFi310.h
@@ -1,0 +1,92 @@
+/**
+ * @file       BlynkSimpleEsp8266.h
+ * @author     OpusK
+ * @license    This project is released under the MIT License (MIT)
+ * @copyright  
+ * @date       Apr 2017
+ * @brief
+ *
+ */
+
+#ifndef BlynkSimpleWizFi310_H
+#define BlynkSimpleWizFi310_H
+
+#include <BlynkApiArduino.h>
+#include <Blynk/BlynkProtocol.h>
+#include <Adapters/BlynkArduinoClient.h>
+#include "WizFi310.h"
+
+class BlynkWifi
+    : public BlynkProtocol<BlynkArduinoClient>
+{
+    typedef BlynkProtocol<BlynkArduinoClient> Base;
+public:
+    BlynkWifi(BlynkArduinoClient& transp)
+        : Base(transp)
+    {}
+
+    void connectWiFi(const char* ssid, const char* pass)
+    {
+        BLYNK_LOG2(BLYNK_F("Connecting to "), ssid);
+
+        if (pass && strlen(pass)) {
+            WiFi.begin(ssid, pass);
+        } else {
+            WiFi.begin(ssid);
+        }
+        while (WiFi.status() != WL_CONNECTED) {
+            ::delay(500);
+        }
+        BLYNK_LOG1(BLYNK_F("Connected to WiFi"));
+
+        IPAddress myip = WiFi.localIP();
+        BLYNK_LOG_IP("IP: ", myip);
+    }
+
+    void config(const char* auth,
+                const char* domain = BLYNK_DEFAULT_DOMAIN,
+                uint16_t    port   = BLYNK_DEFAULT_PORT)
+    {
+        Base::begin(auth);
+        this->conn.begin(domain, port);
+    }
+
+    void config(const char* auth,
+                IPAddress   ip,
+                uint16_t    port = BLYNK_DEFAULT_PORT)
+    {
+        Base::begin(auth);
+        this->conn.begin(ip, port);
+    }
+
+    void begin(const char* auth,
+               const char* ssid,
+               const char* pass,
+               const char* domain = BLYNK_DEFAULT_DOMAIN,
+               uint16_t    port   = BLYNK_DEFAULT_PORT)
+    {
+        connectWiFi(ssid, pass);
+        config(auth, domain, port);
+        while(this->connect() != true) {}
+    }
+
+    void begin(const char* auth,
+               const char* ssid,
+               const char* pass,
+               IPAddress   ip,
+               uint16_t    port   = BLYNK_DEFAULT_PORT)
+    {
+        connectWiFi(ssid, pass);
+        config(auth, ip, port);
+        while(this->connect() != true) {}
+    }
+
+};
+
+static WiFiClient _blynkWifiClient;
+static BlynkArduinoClient _blynkTransport(_blynkWifiClient);
+BlynkWifi Blynk(_blynkTransport);
+
+#include <BlynkWidgets.h>
+
+#endif /* BlynkSimpleWizFi310_H */


### PR DESCRIPTION
### Description
Add new device : WIZnet's [WizFi310](http://wizwiki.net/wiki/doku.php?id=osh:wizfi310_shield:start)
WizFi310 is a WiFi module.
If you search [WizFi310 in Library Manager](https://github.com/Wiznet/WizFi310_arduino_library), you can download it.





