### PR TITLE
Do syncAll() on every re-connection

### DIFF
--- a/examples/More/Sync/HardwareSyncStateFromApp/HardwareSyncStateFromApp.ino
+++ b/examples/More/Sync/HardwareSyncStateFromApp/HardwareSyncStateFromApp.ino
@@ -39,20 +39,13 @@
 // Go to the Project Settings (nut icon).
 char auth[] = "YourAuthToken";
 
-// Keep this flag not to re-sync on every reconnection
-bool isFirstConnect = true;
-
 // This function will run every time Blynk connection is established
 BLYNK_CONNECTED() {
-  if (isFirstConnect) {
-    // Request Blynk server to re-send latest values for all pins
-    Blynk.syncAll();
+  // Request Blynk server to re-send latest values for all pins
+  Blynk.syncAll();
 
-    // You can also update individual virtual pins like this:
-    //Blynk.syncVirtual(V0, V2);
-
-    isFirstConnect = false;
-  }
+  // You can also update individual virtual pins like this:
+  //Blynk.syncVirtual(V0, V2);
 
   // Let's write your hardware uptime to Virtual Pin 2
   int value = millis() / 1000;


### PR DESCRIPTION
### Description
In example sketch _HardwareSyncStateFromApp_, perform a _syncAll()_ on every re-connection, via *BLYNK_CONNECTED()*, not just the upon the initial connection.

### Issues Resolved
Using the code in this example, if a device that was previously connected to the server loses connection, and then the value of a widget is updated in the app while the device's connection is still down, _syncAll()_ should be called to cause an update to the new value upon device re-connection. This wasn't happening because there was code to use a semaphore flag, _isFirstConnect_, to only call _syncAll()_ upon the initial connection.

### Note:
[The example in the Blynk documentation](http://docs.blynk.cc/#blynk-firmware-virtual-pins-control-blynksyncall) should also be updated to always do the _syncAll()_ and not have `if (isFirstConnect) {`, to match these modificatons made to the _HardwareSyncStateFromApp_ example sketch.