### PR TITLE
Fix bugs about headers and timer's variable usage

### DIFF
--- a/src/Blynk/BlynkProtocol.h
+++ b/src/Blynk/BlynkProtocol.h
@@ -351,7 +351,8 @@ bool BlynkProtocol<Transp>::processInput(void)
         uint32_t cmd32;
         memcpy(&cmd32, it.asStr(), sizeof(cmd32));
 
-        char* start = (char*)(it++).asStr();
+        char* start = (char*)(it).asStr();
+	++it;
         unsigned length = hdr.length - (start - (char*)inputBuffer);
         BlynkParam param2(start, length);
 

--- a/src/utility/BlynkTimer.cpp
+++ b/src/utility/BlynkTimer.cpp
@@ -28,6 +28,7 @@
 
 
 #include "Blynk/BlynkTimer.h"
+#include <cstring>
 
 
 // Select time function:
@@ -261,7 +262,7 @@ void SimpleTimer::disable(unsigned numTimer) {
 void SimpleTimer::enableAll() {
     // Enable all timers with a callback assigned (used)
     for (int i = 0; i < MAX_TIMERS; i++) {
-        if (timer[i].callback != NULL && numRuns[i] == RUN_FOREVER) {
+        if (timer[i].callback != NULL && timer[i].numRuns == RUN_FOREVER) {
             timer[i].enabled = true;
         }
     }
@@ -270,7 +271,7 @@ void SimpleTimer::enableAll() {
 void SimpleTimer::disableAll() {
     // Disable all timers with a callback assigned (used)
     for (int i = 0; i < MAX_TIMERS; i++) {
-        if (timer[i].callback != NULL && numRuns[i] == RUN_FOREVER) {
+        if (timer[i].callback != NULL && timer[i].numRuns == RUN_FOREVER) {
             timer[i].enabled = false;
         }
     }


### PR DESCRIPTION

### Description
All these issues appear under Raspberry PI 3B, when building with command `make all target=raspberry`
1. The original usage of iterator has a problem, the suffix++ is not overridden. 
2. Without header <cstring>, the memset has no declaration.
3. The usage of numRuns[i] of a timer is not correct, replace it with timer[i].numRuns

### Issues Resolved
1. For the iterator it++, replace it with two single statements.
2. For memset, include the header <cstring>
3. For numRuns[i], replace it with timer[i].numRuns
