### PR TITLE
Added examples sketches for RTL8195A/RTL8711AM chipsets

### DIFF
--- a/examples/Boards_WiFi/RTL8195_WiFi/RTL8195_WiFi.ino
+++ b/examples/Boards_WiFi/RTL8195_WiFi/RTL8195_WiFi.ino
@@ -1,0 +1,61 @@
+/*************************************************************
+  Download latest Blynk library here:
+    https://github.com/blynkkk/blynk-library/releases/latest
+
+  Blynk is a platform with iOS and Android apps to control
+  Arduino, Raspberry Pi and the likes over the Internet.
+  You can easily build graphic interfaces for all your
+  projects by simply dragging and dropping widgets.
+
+    Downloads, docs, tutorials: http://www.blynk.cc
+    Sketch generator:           http://examples.blynk.cc
+    Blynk community:            http://community.blynk.cc
+    Follow us:                  http://www.fb.com/blynkapp
+                                http://twitter.com/blynk_app
+
+  Blynk library is licensed under MIT license
+  This example code is in public domain.
+
+ *************************************************************
+  This example runs directly on REALTEK RTL8195A/8711AM chip.
+
+  Note: This requires RTL8195A support package:
+    https://github.com/Ameba8195/Arduino
+
+  Please be sure to select the right REALTEK RTL8195A/8711AM module
+  in the Tools -> Board menu!
+
+  Change WiFi ssid, pass, and Blynk auth token to run :)
+  Feel free to apply it to any other example. It's simple!
+ *************************************************************/
+
+/* Comment this out to disable prints and save space */
+#define BLYNK_PRINT Serial
+
+
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <BlynkSimpleRTL8195.h>
+
+// You should get Auth Token in the Blynk App.
+// Go to the Project Settings (nut icon).
+char auth[] = "YourAuthToken";
+
+// Your WiFi credentials.
+// Set password to "" for open networks.
+char ssid[] = "YourNetworkName";
+char pass[] = "YourPassword";
+
+void setup()
+{
+  // Debug console
+  Serial.begin(9600);
+
+  Blynk.begin(auth, ssid, pass);
+}
+
+void loop()
+{
+  Blynk.run();
+}
+

--- a/src/BlynkSimpleRTL8195.h
+++ b/src/BlynkSimpleRTL8195.h
@@ -1,0 +1,98 @@
+/**
+ * @file       BlynkSimpleRTL8195.h
+ * @author     Naresh Krish Shymanskyy
+ * @license    This project is released under the MIT License (MIT)
+ * @copyright  Copyright (c) 2015 Volodymyr Shymanskyy
+ * @date       Oct 2016
+ * @brief
+ *
+ */
+
+#ifndef BlynkSimpleRTL8195AM_h
+#define BlynkSimpleRTL8195AM_h
+
+#ifndef BOARD_RTL8195A
+#error This code is intended to run on the REALTEK RTL8195AM platform! Please check your Tools->Board setting.
+#endif
+
+#define BLYNK_SEND_ATOMIC
+
+#include <BlynkApiArduino.h>
+#include <Blynk/BlynkProtocol.h>
+#include <Adapters/BlynkArduinoClient.h>
+#include <WiFi.h>
+
+class BlynkWifi
+    : public BlynkProtocol<BlynkArduinoClient>
+{
+    typedef BlynkProtocol<BlynkArduinoClient> Base;
+public:
+    BlynkWifi(BlynkArduinoClient& transp)
+        : Base(transp)
+    {}
+
+    void connectWiFi(char* ssid, char* pass)
+    {
+        BLYNK_LOG2(BLYNK_F("Connecting to "), ssid);
+        //WiFi.mode(WIFI_STA);
+        if (pass && strlen(pass)) {
+            WiFi.begin(ssid, pass);
+        } else {
+            WiFi.begin(ssid);
+        }
+        while (WiFi.status() != WL_CONNECTED) {
+            BlynkDelay(500);
+        }
+        BLYNK_LOG1(BLYNK_F("Connected to WiFi"));
+
+        IPAddress myip = WiFi.localIP();
+        BLYNK_LOG_IP("IP: ", myip);
+    }
+
+    void config(const char* auth,
+                const char* domain = BLYNK_DEFAULT_DOMAIN,
+                uint16_t    port   = BLYNK_DEFAULT_PORT)
+    {
+        Base::begin(auth);
+        this->conn.begin(domain, port);
+    }
+
+    void config(const char* auth,
+                IPAddress   ip,
+                uint16_t    port = BLYNK_DEFAULT_PORT)
+    {
+        Base::begin(auth);
+        this->conn.begin(ip, port);
+    }
+
+    void begin(const char* auth,
+               char* ssid,
+               char* pass,
+               const char* domain = BLYNK_DEFAULT_DOMAIN,
+               uint16_t    port   = BLYNK_DEFAULT_PORT)
+    {
+        connectWiFi(ssid, pass);
+        config(auth, domain, port);
+        while(this->connect() != true) {}
+    }
+
+    void begin(const char* auth,
+               char* ssid,
+               char* pass,
+               IPAddress   ip,
+               uint16_t    port   = BLYNK_DEFAULT_PORT)
+    {
+        connectWiFi(ssid, pass);
+        config(auth, ip, port);
+        while(this->connect() != true) {}
+    }
+
+};
+
+static WiFiClient _blynkWifiClient;
+static BlynkArduinoClient _blynkTransport(_blynkWifiClient);
+BlynkWifi Blynk(_blynkTransport);
+
+#include <BlynkWidgets.h>
+
+#endif

--- a/src/BlynkSimpleRTL8195.h
+++ b/src/BlynkSimpleRTL8195.h
@@ -34,7 +34,6 @@ public:
     void connectWiFi(char* ssid, char* pass)
     {
         BLYNK_LOG2(BLYNK_F("Connecting to "), ssid);
-        //WiFi.mode(WIFI_STA);
         if (pass && strlen(pass)) {
             WiFi.begin(ssid, pass);
         } else {


### PR DESCRIPTION
<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
This pull request aims at extending the support for the REALTEK wifi chipsets. The PR contains a basic example sketch and the associated header file changes for REALTEK 8195A/8711AM based boards. The example has been tested on the RAK creator pro boards (powerted by the RTL8711AM) and also on the official REALTEK Ameba 8195AM dev board. 

### Issues Resolved
This pull request is for an enhancement and hence there are no issues resolved as such
