### PR TITLE
Do not force WiFi Connect if already connected

### DIFF
--- a/src/BlynkSimpleEsp8266.h
+++ b/src/BlynkSimpleEsp8266.h
@@ -33,10 +33,12 @@ public:
     {
         BLYNK_LOG2(BLYNK_F("Connecting to "), ssid);
         WiFi.mode(WIFI_STA);
-        if (pass && strlen(pass)) {
-            WiFi.begin(ssid, pass);
-        } else {
-            WiFi.begin(ssid);
+        if (WiFi.status() != WL_CONNECTED) {
+            if (pass && strlen(pass)) {
+                WiFi.begin(ssid, pass);
+            } else {
+                WiFi.begin(ssid);
+            }
         }
         while (WiFi.status() != WL_CONNECTED) {
             BlynkDelay(500);

--- a/src/BlynkSimpleEsp8266_SSL.h
+++ b/src/BlynkSimpleEsp8266_SSL.h
@@ -109,10 +109,12 @@ public:
     {
         BLYNK_LOG2(BLYNK_F("Connecting to "), ssid);
         WiFi.mode(WIFI_STA);
-        if (pass && strlen(pass)) {
-            WiFi.begin(ssid, pass);
-        } else {
-            WiFi.begin(ssid);
+        if (WiFi.status() != WL_CONNECTED) {
+            if (pass && strlen(pass)) {
+                WiFi.begin(ssid, pass);
+            } else {
+                WiFi.begin(ssid);
+            }
         }
         while (WiFi.status() != WL_CONNECTED) {
             BlynkDelay(500);


### PR DESCRIPTION
Do not force WiFi Connect if already connected, as WiFi.begin() is
likely to get stucked.

<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
If ESP8266 is already connected, WiFi.begin() will get stuck. I was doing a sketch with WebUpdate and I was really missing that, because Blynk killed entire device on mode change (because WiFi has been previously connected in WebUpload mode)

### Issues Resolved
I don't think there is any
