### PR TITLE
linux/BlynkSocket: avoid warnings now that port is uint16

### DIFF
--- a/linux/BlynkSocket.h
+++ b/linux/BlynkSocket.h
@@ -29,7 +29,7 @@ class BlynkTransportSocket
 {
 public:
     BlynkTransportSocket()
-        : sockfd(-1), domain(NULL), port(NULL)
+        : sockfd(-1), domain(NULL)
     {}
 
     void begin(const char* h, uint16_t p) {


### PR DESCRIPTION
Now that the port variable is a uint16 instead of a string, we don't
want to have the default initializer anymore, it causes warnings about
incorrect types.

Signed-off-by: Karl Palsson <karlp@etactica.com>

Issues resolved: none filed.