### PR TITLE
Add new device : WizFi250

### DIFF
--- a/examples/Boards_WiFi/WizFi250/WizFi250.ino
+++ b/examples/Boards_WiFi/WizFi250/WizFi250.ino
@@ -1,0 +1,59 @@
+/*************************************************************
+  Download latest Blynk library here:
+    https://github.com/blynkkk/blynk-library/releases/latest
+
+  Blynk is a platform with iOS and Android apps to control
+  Arduino, Raspberry Pi and the likes over the Internet.
+  You can easily build graphic interfaces for all your
+  projects by simply dragging and dropping widgets.
+
+    Downloads, docs, tutorials: http://www.blynk.cc
+    Sketch generator:           http://examples.blynk.cc
+    Blynk community:            http://community.blynk.cc
+    Follow us:                  http://www.fb.com/blynkapp
+                                http://twitter.com/blynk_app
+
+  Blynk library is licensed under MIT license
+  This example code is in public domain.
+
+ *************************************************************
+  This example shows how to use WizFi250
+  to connect your project to Blynk.
+
+  Note: This requires WizFi250 library
+    from http://librarymanager/all#WizFi250
+
+  Feel free to apply it to any other example. It's simple!
+ *************************************************************/
+
+/* Comment this out to disable prints and save space */
+#define BLYNK_PRINT Serial
+
+
+#include <WizFi250.h>
+#include <BlynkSimpleWizFi250.h>
+
+// You should get Auth Token in the Blynk App.
+// Go to the Project Settings (nut icon).
+char auth[] = "YourAuthToken";
+
+// Your WiFi credentials.
+// Set password to "" for open networks.
+char ssid[] = "YourNetworkName";
+char pass[] = "YourPassword";
+
+void setup()
+{
+  // Debug console
+  Serial.begin(9600);
+  WiFi.init();
+  Blynk.begin(auth, ssid, pass);
+  // You can also specify server:
+  //Blynk.begin(auth, ssid, pass, "blynk-cloud.com", 80);
+  //Blynk.begin(auth, ssid, pass, IPAddress(192,168,1,100), 8080);
+}
+
+void loop()
+{
+  Blynk.run();
+}

--- a/src/Adapters/BlynkWizFi250.h
+++ b/src/Adapters/BlynkWizFi250.h
@@ -1,0 +1,107 @@
+/**
+ * @file       BlynkWiFiCommon.h
+ * @author     Volodymyr Shymanskyy
+ * @license    This project is released under the MIT License (MIT)
+ * @copyright  Copyright (c) 2015 Volodymyr Shymanskyy
+ * @date       Jan 2015
+ * @brief
+ *
+ */
+
+#ifndef BlynkWizFi250_h
+#define BlynkWizFi250_h
+
+#ifndef BLYNK_INFO_CONNECTION
+#define BLYNK_INFO_CONNECTION "WiFi"
+#endif
+
+#ifdef BLYNK_USE_SSL
+  #define BLYNK_SERVER_PORT BLYNK_DEFAULT_PORT_SSL
+#else
+  #define BLYNK_SERVER_PORT BLYNK_DEFAULT_PORT
+#endif
+
+#include <BlynkApiArduino.h>
+#include <Blynk/BlynkProtocol.h>
+#include <Adapters/BlynkArduinoClient.h>
+
+class BlynkWifiCommon
+    : public BlynkProtocol<BlynkArduinoClient>
+{
+    typedef BlynkProtocol<BlynkArduinoClient> Base;
+public:
+    BlynkWifiCommon(BlynkArduinoClient& transp)
+        : Base(transp)
+    {}
+
+    void connectWiFi(const char* ssid, const char* pass)
+    {
+        int status = WiFi.status();
+        // check for the presence of the shield:
+        if (status == WL_NO_SHIELD) {
+            BLYNK_FATAL("WiFi module not found");
+        }
+
+#ifdef BLYNK_DEBUG
+        BLYNK_LOG2(BLYNK_F("WiFi firmware: "), WiFi.firmwareVersion());
+#endif
+
+        // attempt to connect to Wifi network:
+        while (status != WL_CONNECTED) {
+            BLYNK_LOG2(BLYNK_F("Connecting to "), ssid);
+            status = WiFi.begin((char*)ssid, (const char*)pass);
+
+            millis_time_t started = BlynkMillis();
+            while ((status != WL_CONNECTED) &&
+                  (BlynkMillis() - started < 10000))
+            {
+                BlynkDelay(100);
+                status = WiFi.status();
+            }
+        }
+
+        IPAddress myip = WiFi.localIP();
+        BLYNK_LOG_IP("IP: ", myip);
+    }
+
+    void config(const char* auth,
+                const char* domain = BLYNK_DEFAULT_DOMAIN,
+                uint16_t    port   = BLYNK_SERVER_PORT)
+    {
+        Base::begin(auth);
+        this->conn.begin(domain, port);
+    }
+
+    void config(const char* auth,
+                IPAddress   ip,
+                uint16_t    port = BLYNK_SERVER_PORT)
+    {
+        Base::begin(auth);
+        this->conn.begin(ip, port);
+    }
+
+    void begin(const char* auth,
+               const char* ssid,
+               const char* pass,
+               const char* domain = BLYNK_DEFAULT_DOMAIN,
+               uint16_t    port   = BLYNK_SERVER_PORT)
+    {
+        connectWiFi(ssid, pass);
+        config(auth, domain, port);
+        while(this->connect() != true) {}
+    }
+
+    void begin(const char* auth,
+               const char* ssid,
+               const char* pass,
+               IPAddress   ip,
+               uint16_t    port   = BLYNK_SERVER_PORT)
+    {
+        connectWiFi(ssid, pass);
+        config(auth, ip, port);
+        while(this->connect() != true) {}
+    }
+
+};
+
+#endif

--- a/src/BlynkSimpleWizFi250.h
+++ b/src/BlynkSimpleWizFi250.h
@@ -1,0 +1,29 @@
+/**
+ * @file BlynkSimpleWizFi310.h
+ * @
+ * @license This project is released under the MIT License (MIT)
+ * @copyright Copyright (c) 2015 Volodymyr Shymanskyy
+ * @date Oct 2017
+ * @brief
+ *
+ */
+#ifndef BlynkSimpleWizFi250_h
+#define BlynkSimpleWizFi250_h
+
+#ifndef BLYNK_INFO_CONNECTION
+#define BLYNK_INFO_CONNECTION  "WizFi250"
+#endif
+
+#define BLYNK_SEND_ATOMIC
+#define BLYNK_SEND_CHUNK 64
+
+#include <WizFi250.h>
+#include <Adapters/BlynkWizFi250.h>
+
+static WiFiClient _blynkWifiClient;
+static BlynkArduinoClient _blynkTransport(_blynkWifiClient);
+BlynkWifiCommon Blynk(_blynkTransport);
+
+#include <BlynkWidgets.h>
+
+#endif


### PR DESCRIPTION
hi @vshymanskyy 

### Description
Implemented the support file, required to make works Blynk with WizFi250:

Implemented the the header file BlynkSimpleWizFi250.h;
Implemented the the header file src\Adapters\BlynkWizFi250.h;
Implemented the example examples\Boards_WiFi\WizFi250\WizFi250.ino


WizFi250 is a lower version module of the WizFi310.

BylnkWizFi250 is almost the same as the WizFi310.
WizFi250 library is available download from the library manager :)

reference : https://www.wiznet.io/product-item/wizfi250/

There was nothing wrong with the test.
thanks!

