### PR TITLE
Set fingerprint also in the client

### DIFF
--- a/src/BlynkSimpleEsp8266_SSL.h
+++ b/src/BlynkSimpleEsp8266_SSL.h
@@ -51,7 +51,10 @@ public:
         , fingerprint(NULL)
     {}
 
-    void setFingerprint(const char* fp) { fingerprint = fp; }
+    void setFingerprint(const char* fp) {
+      fingerprint = fp;
+      this->client->setFingerprint(fp);
+    }
 
     bool setCACert(const uint8_t* caCert, unsigned caCertLen) {
         bool res = this->client->setCACert(caCert, caCertLen);


### PR DESCRIPTION
<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
My use case is using a self-signed certificate and its fingerprint for validation.

This PR makes the following code use the fingerprint and work as expected:
> Blynk.begin(auth, ssid, pass, ip, port, fingerprint);

otherwise the `WiFiClientSecure::connect()` method fails to validate the SSL connection and returns the following error if debug messages are enabled or silently fails otherwise:
> BSSL:Couldn't connect. Error = 'Chain could not be linked to a trust anchor.'

A workaround, without applying this PR is:
>  _blynkWifiClient.setFingerprint(fingerprint);
>  Blynk.begin(auth, ssid, pass, ip, port, fingerprint);

### Issues Resolved
Using the fingerprint fails to establish an SSL connection.
