### PR TITLE
Added getBuffSize() function to BlynkParam class.

### DIFF
--- a/src/Blynk/BlynkParam.h
+++ b/src/Blynk/BlynkParam.h
@@ -102,6 +102,7 @@ public:
 
     void*  getBuffer() const { return (void*)buff; }
     size_t getLength() const { return len; }
+    size_t getBuffSize() const { return buff_size; }
 
     // Modification
     void add(int value);


### PR DESCRIPTION
<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
Added public getBuffSize() function to BlynkParam class. I found this useful when creating classes that inherit from BlynkParam. Having the buffer size allows creating a Copy Constructor for the new class that take a reference to a BlynkParam class object. The object of the inherited class will then be constructed with the same buffer size as the BlynkParam object.

### Issues Resolved
Addresses Issue #510 that I recently entered.
