### PR TITLE
Update BlynkSimpleEsp8266.h

### DIFF
--- a/src/BlynkSimpleEsp8266.h
+++ b/src/BlynkSimpleEsp8266.h
@@ -55,6 +55,31 @@ public:
         (void)myip; // Eliminate warnings about unused myip
         BLYNK_LOG_IP("IP: ", myip);
     }
+    
+    bool connectWiFi_t(const char* ssid, 
+                       const char* pass, 
+                       uint16_t timeout = 10000)
+    {
+        BLYNK_LOG2(BLYNK_F("Connecting to "), ssid);
+        WiFi.mode(WIFI_STA);
+        if (WiFi.status() != WL_CONNECTED) {
+          if (pass && strlen(pass)) {
+            WiFi.begin(ssid, pass);
+          } else {
+            WiFi.begin(ssid);
+          }
+        }
+		int WFB = timeout / 500;  // set default 20 cycles 
+        while ((WiFi.status() != WL_CONNECTED) && (WFB>0)) {
+          BlynkDelay(500);
+		  --WFB;
+        }
+        if (WiFi.status() != WL_CONNECTED) return false;		
+        BLYNK_LOG1(BLYNK_F("Connected to WiFi"));
+        IPAddress myip = WiFi.localIP();
+        BLYNK_LOG_IP("IP: ", myip);
+		return true;
+    }
 
     void config(const char* auth,
                 const char* domain = BLYNK_DEFAULT_DOMAIN,
@@ -92,6 +117,24 @@ public:
         connectWiFi(ssid, pass);
         config(auth, ip, port);
         while(this->connect() != true) {}
+    }
+    
+    
+
+    bool begin_t(const char* auth,
+                 const char* ssid,
+                 const char* pass,
+                 IPAddress   ip,
+                 uint16_t    port   = BLYNK_DEFAULT_PORT,
+			     uint16_t wifi_timeout = 30000)
+    {
+		if (WiFi.status() != WL_CONNECTED) {
+		  uint16_t connect_count = wifi_timeout / 10000;
+          while ((connectWiFi_t(ssid, pass, wifi_timeout / 3)) && (connect_count>0)) --connect_count;   
+		  if (WiFi.status() != WL_CONNECTED) return false;
+		}
+        config(auth, ip, port);
+		return this->connect();
     }
 
 };


### PR DESCRIPTION
modified the library so that it was possible to limit the time of attempts to establish a connection and their number, in order to be able to somehow fork the connection script.

<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
Add 2 functions **connectWiFi_t** and **begin_t**

**Usage example**

```
int conB_count = 5;
while ((!Blynk.begin_t(auth, ssid, pass, IPAddress(172,18,0,100), 8080, 30000)) && (conB_count>0))  --conB_count;
if (WiFi.status() != WL_CONNECTED) ESP.restart();
```

### Issues Resolved
after long testing, I found out that after waking up from sleep, the connection to the access point can take up to 30 seconds or more. sometimes frozen.
I modified the library so that it was possible to limit the time of attempts to establish a connection and their number, in order to be able to somehow fork the connection script.
