### PR TITLE
Added option to compile dynamic library

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -11,6 +11,11 @@ CXX ?= g++
 CXXFLAGS += -I ../src/ -I ./ -DLINUX
 LDFLAGS += -lrt -lpthread
 
+ifeq ($(PREFIX),)
+	PREFIX := /usr/local
+endif
+FULLPREFIX=${DESTDIR}/${PREFIX}
+
 ifeq ($(build),debug)
 	CXXFLAGS += -c -g2 -O0 \
 		-Wall -Weffc++ \
@@ -34,12 +39,12 @@ ifeq ($(build),debug)
 		-Wunused-function  -Wunused-label  \
 		-Wunused-value  -Wunused-variable \
 		-Wvolatile-register-var  -Wwrite-strings
-	
-	# Disable some warnings
+
+# Disable some warnings
 	CXXFLAGS += -Wno-variadic-macros -Wno-unused-parameter -Wno-vla
-	
-	# Uncomment this to get pedantic warnings:
-	#CXXFLAGS += -pedantic -Wvariadic-macros -Wunused-parameter -Waggregate-return -Wcast-qual -Wpadded
+
+# Uncomment this to get pedantic warnings:
+#CXXFLAGS += -pedantic -Wvariadic-macros -Wunused-parameter -Waggregate-return -Wcast-qual -Wpadded
 else
 	CXXFLAGS += -c -O3 -w
 	LDFLAGS += -s
@@ -50,21 +55,64 @@ ifeq ($(target),raspberry)
 	LDFLAGS += -lwiringPi
 endif
 
-SOURCES=main.cpp \
-	../src/utility/BlynkDebug.cpp \
-	../src/utility/BlynkHandlers.cpp \
-	../src/utility/BlynkTimer.cpp
+LIBSOURCES=	../src/utility/BlynkDebug.cpp \
+            ../src/utility/BlynkHandlers.cpp \
+            ../src/utility/BlynkTimer.cpp
 
-OBJECTS=$(SOURCES:.cpp=.o)
-EXECUTABLE=blynk
+USRHEADERS= *.h
+COREHEADERS=  ../src/Blynk/*.h
+UTILHEADERS= ../src/utility/*.h
 
-all: $(SOURCES) $(EXECUTABLE)
+ALLSOURCES=main.cpp $(LIBSOURCES)
+
+ALLOBJECTS=$(ALLSOURCES:.cpp=.o)
+EXECUTABLE=blynk-demo
+
+LIBOBJECTS=$(LIBSOURCES:.cpp=.o)
+LIBRARY=libblynk.so
+
+PKGCONFIG=libblynk.pc
+
+all: $(ALLSOURCES) $(EXECUTABLE) $(LIBRARY)
+
+library: $(LIBRARY) $(PKGCONFIG)
 
 clean:
-	-rm $(OBJECTS) $(EXECUTABLE)
+	-rm -f $(ALLOBJECTS) $(EXECUTABLE) $(LIBRARY) $(PKGCONFIG)
 
-$(EXECUTABLE): $(OBJECTS) 
-	$(CXX) $(OBJECTS) $(LDFLAGS) -o $@
+$(EXECUTABLE): $(ALLOBJECTS) $(LIBRARY)
+	$(CXX) $(ALLOBJECTS) $(LDFLAGS) -o $@
+
+$(LIBRARY): $(LIBOBJECTS)
+	$(CXX) $(LIBOBJECTS) $(LDFLAGS) -shared -o $(LIBRARY)
+
+install: $(LIBRARY) $(PKGCONFIG)
+	install -d $(FULLPREFIX)/lib/libblynk/
+	install -m 755 $(LIBRARY) $(FULLPREFIX)/lib/libblynk/
+	install -d $(FULLPREFIX)/include/libblynk/
+	install -m 644 ${USRHEADERS} $(FULLPREFIX)/include/libblynk/
+	install -d $(FULLPREFIX)/include/libblynk/Blynk/
+	install -m 644 ${COREHEADERS} $(FULLPREFIX)/include/libblynk/Blynk/
+	install -d $(FULLPREFIX)/include/libblynk/utility/
+	install -m 644 ${UTILHEADERS} $(FULLPREFIX)/include/libblynk/utility/
+	install -d $(FULLPREFIX)/lib/pkgconfig/
+	install -m 644 ${PKGCONFIG} $(FULLPREFIX)/lib/pkgconfig/
+	echo "$(FULLPREFIX)/lib/libblynk" >/etc/ld.so.conf.d/libblynk.conf
+	ldconfig ${FULLPREFIX}
+
+uninstall:
+	rm -rf ${FULLPREFIX}/lib/libblynk/
+	rm -rf ${FULLPREFIX}/include/libblynk/
+	rm -f ${FULLPREFIX}/lib/pkgconfig/${PKGCONFIG}
+	rm -f /etc/ld.so.conf.d/libblynk.conf
+	ldconfig ${FULLPREFIX}
 
 .cpp.o:
-	$(CXX) $(CXXFLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) -fPIC $< -o $@
+
+$(PKGCONFIG):
+	echo "Name: Blynk Library"  >>$(PKGCONFIG)
+	echo "Description: C Utility Library"  >>$(PKGCONFIG)
+	echo "Version: 0.0" >>$(PKGCONFIG)
+	echo "Cflags: -I${FULLPREFIX}/include/libblynk/"  >>$(PKGCONFIG)
+	echo "Libs: -L${FULLPREFIX}/lib/libblynk -lblynk"  >>$(PKGCONFIG)

--- a/linux/README.md
+++ b/linux/README.md
@@ -22,3 +22,11 @@ We have also provided a build script, you can try just running (inside of the "l
 ```bash
 $ ./build.sh raspberry
 ```
+
+To build a dynamic library that can be installed system-wide, try:
+```bash
+$ make target=raspberry libblynk.so
+$ sudo make install
+```
+
+Then see ./library-test/ for a small sample code on how to use the library in your own project.

--- a/linux/library-demo/Makefile
+++ b/linux/library-demo/Makefile
@@ -1,0 +1,30 @@
+# 
+# To build on RaspberryPi:
+# 1. Install WiringPi: http://wiringpi.com/download-and-install/
+# 2. Build & install the blynk library system-wide
+# 2. Run:
+#    make
+
+CC ?= gcc
+CXX ?= g++
+
+CXXFLAGS+= `pkg-config --cflags libblynk`  
+LDFLAGS +=  `pkg-config --libs libblynk`
+
+ifeq ($(PREFIX),)
+	PREFIX := /usr/local
+endif
+FULLPREFIX=${DESTDIR}/${PREFIX}
+
+CXXFLAGS += -O3 -w
+LDFLAGS += -s
+LDFLAGS += -lwiringPi
+
+all: blynkTest
+
+clean:
+	-rm -f blynkTest
+
+$(EXECUTABLE): blynkTest.cpp
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) blynkTest.cpp -o blynkTest
+

--- a/linux/library-demo/blynkTest.cpp
+++ b/linux/library-demo/blynkTest.cpp
@@ -1,0 +1,40 @@
+// Simple test for the blynk library on the Raspberry.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <BlynkSocket.h>
+#include <wiringPi.h>
+#include <BlynkApiWiringPi.h>
+
+#define  AUTH "your-api-key" // add your API key here
+
+static BlynkTransportSocket _blynkTransport;
+BlynkSocket Blynk(_blynkTransport);
+
+int main(int argc, char* argv[])
+{
+    unsigned int val = 0;
+    static unsigned int sec=0;
+
+    srand(time(NULL));
+    Blynk.begin( AUTH );
+
+
+    while( 1 )
+    {
+
+        Blynk.run(); // Blynk housekeeping
+        sleep (1); // 1 sec
+        if( ++sec >= 60)
+        {
+            sec = 0;
+            val = (rand() % 500); // 0..499
+            printf( "Random value: %d\n", val );
+            Blynk.virtualWrite(V01, val );   // Send value to Blynk's V01
+        } // if <minute passed>
+
+    }
+}


### PR DESCRIPTION
- Modified Makefile to allow for compilation & installation of a dynamically loaded library for
  Raspberry
- Added small demo code in library-demo/ on how to use this library

<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
Adds option to linux/Makefile to crate a dynamically linked library. And install said lib.
Pls review the Makefile -- the auto-generated pkg-config file sets a default library verion nmbr of 0.0 for now. You may want to automate this with your release system.

### Issues Resolved
n/a
