### PR TITLE
Fixed call esp_bt_gap_set_scan_mode()

### DIFF
--- a/src/BlynkSimpleEsp32_BT.h
+++ b/src/BlynkSimpleEsp32_BT.h
@@ -152,7 +152,7 @@ class BlynkTransportEsp32_BT
       switch (event)
       {
         case ESP_SPP_INIT_EVT: // Once the SPP callback has been registered, ESP_SPP_INIT_EVT is triggered
-          esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
+          esp_bt_gap_set_scan_mode(ESP_BT_CONNECTABLE, ESP_BT_GENERAL_DISCOVERABLE);
           esp_spp_start_srv(ESP_SPP_SEC_NONE, ESP_SPP_ROLE_SLAVE, 0, "SPP_SERVER");
           break;
 


### PR DESCRIPTION
### Description
Fixing "error: 'ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE' was not declared in this scope"

### Issues Resolved
https://github.com/espressif/esp-idf/issues/3219
