### PR TITLE
ESP32 Bluetooth (classic) compilation error in BlynkSimpleEsp32_BT.h

### DIFF
--- a/src/BlynkSimpleEsp32_BT.h
+++ b/src/BlynkSimpleEsp32_BT.h
@@ -152,7 +152,11 @@ class BlynkTransportEsp32_BT
       switch (event)
       {
         case ESP_SPP_INIT_EVT: // Once the SPP callback has been registered, ESP_SPP_INIT_EVT is triggered
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
           esp_bt_gap_set_scan_mode(ESP_BT_CONNECTABLE, ESP_BT_GENERAL_DISCOVERABLE);
+#else
+          esp_bt_gap_set_scan_mode(ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE);
+#endif
           esp_spp_start_srv(ESP_SPP_SEC_NONE, ESP_SPP_ROLE_SLAVE, 0, "SPP_SERVER");
           break;
 


### PR DESCRIPTION
### Description
Fix compilation problem on ESP32 using Bluetooth Classic

### Issues Resolved
In https://github.com/blynkkk/blynk-library/pull/555 a fix was introduced to solve a compilation problem on ESP32 
Fixing "error: 'ESP_BT_SCAN_MODE_CONNECTABLE_DISCOVERABLE' was not declared in this scope"

But this fix introduces a compilation error in previous versions of IDF / ESP32 Arduino Core.

Now it will check the IDF version and depending on version 3 or 4, it will compile using other code.
