### PR TITLE
Add Spresense LTE support

### DIFF
--- a/examples/Boards_GSM/Spresense_LTE/Spresense_LTE.ino
+++ b/examples/Boards_GSM/Spresense_LTE/Spresense_LTE.ino
@@ -1,0 +1,67 @@
+/*************************************************************
+  Download latest Blynk library here:
+    https://github.com/blynkkk/blynk-library/releases/latest
+
+  Blynk is a platform with iOS and Android apps to control
+  Arduino, Raspberry Pi and the likes over the Internet.
+  You can easily build graphic interfaces for all your
+  projects by simply dragging and dropping widgets.
+
+    Downloads, docs, tutorials: http://www.blynk.cc
+    Sketch generator:           http://examples.blynk.cc
+    Blynk community:            http://community.blynk.cc
+    Follow us:                  http://www.fb.com/blynkapp
+                                http://twitter.com/blynk_app
+
+  Blynk library is licensed under MIT license
+  This example code is in public domain.
+
+ *************************************************************
+  This example shows how to use Spresense LTE board
+  to connect your project to Blynk.
+
+  Note: This requires Spresense board package
+    from https://developer.sony.com/develop/spresense
+
+  Change apn, user, pass, and Blynk auth token to run :)
+  Feel free to apply it to any other example. It's simple!
+
+ *************************************************************/
+
+/* Comment this out to disable prints and save space */
+#define BLYNK_PRINT Serial
+
+/* Fill-in your Template ID (only if using Blynk.Cloud) */
+//#define BLYNK_TEMPLATE_ID   "YourTemplateID"
+
+// Default heartbeat interval for GSM is 60
+// If you want override this value, uncomment and set this option:
+//#define BLYNK_HEARTBEAT 30
+
+#include <BlynkSimpleSpresenseLTE.h>
+
+// You should get Auth Token in the Blynk App.
+// Go to the Project Settings (nut icon).
+char auth[] = "YourAuthToken";
+
+// Your GPRS credentials
+// Leave empty, if missing user or pass
+char apn[]  = "YourAPN";
+char user[] = "";
+char pass[] = "";
+
+void setup()
+{
+  // Debug console
+  Serial.begin(115200);
+
+  delay(10);
+
+  Blynk.begin(auth, apn, user, pass);
+}
+
+void loop()
+{
+  Blynk.run();
+}
+

--- a/src/Adapters/BlynkSpresenseLTE.h
+++ b/src/Adapters/BlynkSpresenseLTE.h
@@ -1,0 +1,87 @@
+/**
+ * @file       BlynkSpresenseLTE.h
+ * @author     baggio
+ * @license    This project is released under the MIT License (MIT)
+ * @copyright  Copyright (c) 2022 baggio
+ * @date       May 2022
+ * @brief
+ *
+ */
+
+#ifndef BlynkSpresenseLTE_h
+#define BlynkSpresenseLTE_h
+
+#ifndef BLYNK_INFO_CONNECTION
+#define BLYNK_INFO_CONNECTION "SprLTE"
+#endif
+
+#ifndef BLYNK_HEARTBEAT
+#define BLYNK_HEARTBEAT 60
+#endif
+
+#ifndef BLYNK_TIMEOUT_MS
+#define BLYNK_TIMEOUT_MS 6000
+#endif
+
+#define BLYNK_SEND_ATOMIC
+#define BLYNK_RETRY_SEND
+
+#include <BlynkApiArduino.h>
+#include <Blynk/BlynkProtocol.h>
+#include <Adapters/BlynkArduinoClient.h>
+#include <LTE.h>
+
+class BlynkSIM
+    : public BlynkProtocol<BlynkArduinoClient>
+{
+    typedef BlynkProtocol<BlynkArduinoClient> Base;
+public:
+    BlynkSIM(BlynkArduinoClient& transp)
+        : Base(transp)
+    {}
+
+    bool connectNetwork(const char* apn, const char* user, const char* pass)
+    {
+        // If your SIM has PIN, pass it as a parameter of begin() in quotes
+        BLYNK_LOG1(BLYNK_F("Connecting to network..."));
+        while (true) {
+            if (lte.begin() == LTE_SEARCHING) {
+            if (lte.attach(LTE_NET_RAT_CATM, apn, user, pass) == LTE_READY) {
+                    BLYNK_LOG1(BLYNK_F("Connected to LTE"));
+                    break;
+                }
+                BLYNK_LOG1(BLYNK_F("An error occurred, shutdown and try again."));
+                lte.shutdown();
+                sleep(1);
+            }
+        }
+        return true;
+    }
+
+    void config(const char* auth,
+                const char* domain = BLYNK_DEFAULT_DOMAIN,
+                uint16_t    port   = BLYNK_DEFAULT_PORT)
+    {
+        Base::begin(auth);
+        this->conn.setClient(&client);
+        this->conn.begin(domain, port);
+    }
+
+    void begin(const char* auth,
+               const char* apn,
+               const char* user,
+               const char* pass,
+               const char* domain = BLYNK_DEFAULT_DOMAIN,
+               uint16_t    port   = BLYNK_DEFAULT_PORT)
+    {
+        config(auth, domain, port);
+        connectNetwork(apn, user, pass);
+        while(this->connect() != true) {}
+    }
+
+private:
+    LTE       lte;
+    LTEClient client;
+};
+
+#endif

--- a/src/BlynkSimpleSpresenseLTE.h
+++ b/src/BlynkSimpleSpresenseLTE.h
@@ -1,0 +1,25 @@
+/**
+ * @file       BlynkSimpleSpresenseLTE.h
+ * @author     baggio
+ * @license    This project is released under the MIT License (MIT)
+ * @copyright  Copyright (c) 2022 baggio
+ * @date       May 2022
+ * @brief
+ *
+ */
+
+#ifndef BlynkSimpleSpresenseLTE_h
+#define BlynkSimpleSpresenseLTE_h
+
+#include <Adapters/BlynkSpresenseLTE.h>
+
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_BLYNK)
+  static BlynkArduinoClient _blynkTransport;
+  BlynkSIM Blynk(_blynkTransport);
+#else
+  extern BlynkSIM Blynk;
+#endif
+
+#include <BlynkWidgets.h>
+
+#endif


### PR DESCRIPTION
### Description
Add a new support for Spresense LTE board.
Spresense is basically compatible with the Arduino development environment.
It can be easily connected to Blynk using a Spresense LTE board.
https://developer.sony.com/develop/spresense

### Issues Resolved
None
