### PR TITLE
`defined(__has_include)` and `__has_include(...)` should not be in the same `#if`

### DIFF
--- a/src/Blynk/BlynkTimer.h
+++ b/src/Blynk/BlynkTimer.h
@@ -35,9 +35,11 @@
 #define SIMPLETIMER_H
 #define SimpleTimer BlynkTimer
 
-#if defined(__has_include) && __has_include(<functional>)
+#if defined(__has_include)
+#if __has_include(<functional>)
   #include <functional>
   #define HAS_FUNCTIONAL_H
+#endif
 #endif
 
 class SimpleTimer {


### PR DESCRIPTION
### Description

per https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html
> The first ‘#if’ test succeeds only when the operator is supported by the version of GCC (or another compiler) being used. Only when that test succeeds is it valid to use __has_include as a preprocessor operator. As a result, combining the two tests into a single expression as shown below would only be valid with a compiler that supports the operator but not with others that don’t.

so, we should have two `#if`, checking for macro and only then using it
recent compiler versions obviously work, just noticed this when user tried to use our old Core version shipping with gcc 4.8.x
https://github.com/esp8266/Arduino/issues/8798

### Issues Resolved

\-
